### PR TITLE
New Delegate Methods on WLRemoteLink

### DIFF
--- a/WLRemoteLink.j
+++ b/WLRemoteLink.j
@@ -66,6 +66,7 @@ WLLoginActionDidFailNotification        = "WLLoginDidFailNotification";
 */
 @implementation WLRemoteLink : CPObject
 {
+    id          _delegate @accessors(property=delegate);
     CPArray     actionQueue;
     CPString    baseUrl @accessors;
     int         updateDelay;
@@ -238,6 +239,13 @@ WLLoginActionDidFailNotification        = "WLLoginDidFailNotification";
 - (void)remoteActionDidFail:(WLRemoteAction)anAction dueToAuthentication:(BOOL)dueToAuthentication
 {
     CPLog.error("Action failed " + anAction);
+
+    // Tell the delegate an action has failed
+    if ([_delegate respondsToSelector:@selector(remoteActionDidFail:dueToAuthentication:)])
+    {
+        [_delegate remoteActionDidFail:anAction dueToAuthentication:dueToAuthentication];
+    }
+
     // Ready the action for a later retry.
     [anAction reset];
 
@@ -273,6 +281,13 @@ WLLoginActionDidFailNotification        = "WLLoginDidFailNotification";
 - (void)remoteActionDidFinish:(WLRemoteAction)anAction
 {
     //CPLog.info("Remote op finished: "+[anAction description]);
+
+    // Tell the delegate an action has finished
+    if ([_delegate respondsToSelector:@selector(remoteActionDidFinish:)])
+    {
+        [_delegate remoteActionDidFinish:anAction];
+    }
+
 
     var actionIndex = [actionQueue indexOfObject:anAction];
     if (actionIndex == CPNotFound && ![anAction isLoginAction])


### PR DESCRIPTION
I needed this feature for our app and thought it would be a useful addition to the framework.

The need arose when I wanted my session controller to know whenever a Ratatosk persistence action finished or failed.

This update simply lets you set a `delegate` on the shared `WLRemoteLink object` i.e.:

```
[[WLRemoteLink sharedRemoteLink] setDelegate:self];
```

The delegate will then receive the following messages:

_\- (void)remoteActionDidFail:(WLRemoteAction)anAction dueToAuthentication:(BOOL)dueToAuthentication_

_\- (void)remoteActionDidFinish:(WLRemoteAction)anAction_
