### PR TITLE
Fixed typo

### DIFF
--- a/WLRemoteObject.j
+++ b/WLRemoteObject.j
@@ -125,7 +125,7 @@ function CamelCaseToHyphenated(camelCase)
 */
 + (CPArray)allObjects
 {
-    return [[WLRemoteContext sharedRemoteContext] registeredObjectsForRemoteName:[self removeNmae]];
+    return [[WLRemoteContext sharedRemoteContext] registeredObjectsForRemoteName:[self remoteName]];
 }
 
 + (void)clearInstanceCache


### PR DESCRIPTION
I noticed this small typo while looking through the source for WLRemoteObject.
