### PR TITLE
Fixed a bug where the WLRemoteAction did not have its `connection` property set

### DIFF
--- a/WLRemoteLink.j
+++ b/WLRemoteLink.j
@@ -700,7 +700,7 @@ var WLRemoteActionSerial = 1;
 */
 - (CPURLConnection)makeConnectionWithRequest:(CPURLRequest)aRequest
 {
-    [[self link] sendRequest:aRequest withDelegate:self context:self];
+    connection = [[self link] sendRequest:aRequest withDelegate:self context:self];
 }
 
 - (void)connection:(CPURLConnection)aConnection didReceiveResponse:(CPURLResponse)aResponse


### PR DESCRIPTION
The new `sendRequest:withDelegate:context:` method on WLRemoteLink was returning a CPURLConnection but we were not setting the `connection` property in WLRemoteAction.
