### PR TITLE
Added support for IE's handling of 204 status codes where it returns 1223 instead of 204.

### DIFF
--- a/WLRemoteLink.j
+++ b/WLRemoteLink.j
@@ -611,6 +611,17 @@ var WLRemoteActionSerial = 1;
     return NO;
 }
 
+- (void)setStatusCode:(int)anInt
+{
+    [self willChangeValueForKey:@"statusCode"];
+
+    // IE 8 and 9 can not handle HTTP responses with status code 204 (No Content) properly.
+    // Code 1223 will be used instead. If this happens, we can safely map it to 204.
+    statusCode = (anInt == 1223) ? 204 : anInt;
+
+    [self didChangeValueForKey:@"statusCode"];
+}
+
 /*!
     Reset the action so that it can be retried. This message is sent after an action fails due to
     a network or a server error and will need to be performed a second time.
@@ -713,8 +724,8 @@ var WLRemoteActionSerial = 1;
     {
         var code = [aResponse statusCode];
         [self setStatusCode:code];
-        if (code < 200 || code > 299)
-            CPLog.error("Received error code %d.", code);
+        if (statusCode < 200 || statusCode > 299)
+            CPLog.error("Received error code %d.", statusCode);
     }
 }
 


### PR DESCRIPTION
IE 8 and 9 can not handle HTTP responses with status code 204 (No Content) properly. Code 1223 will be used instead.

Now, when this happens, we map it to 204.

This is a know bug, which is fixed in IE10 and is documented here: http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request

I've tested this in IE 8 & 9.
