### PR TITLE
Fix: Added registration for new WLObjects

### DIFF
--- a/WLRemoteObject.j
+++ b/WLRemoteObject.j
@@ -122,8 +122,8 @@ function CamelCaseToHyphenated(camelCase)
     if (r === nil && shouldCreate)
     {
         r = [self new];
-        // Setting the pk will automatically register it.
         [r setPk:pk];
+        [[WLRemoteContext sharedRemoteContext] registerObject:r];
     }
 
     return r;


### PR DESCRIPTION
The original comment indicated that WLObjects would automatically be registered when the PK would be set. As this wasn't the case this fixed registers them explicitly.
