### PR TITLE
Fixed: Conflicting return types in the init method

### DIFF
--- a/WLRemoteLink.j
+++ b/WLRemoteLink.j
@@ -112,7 +112,7 @@ WLRemoteLinkStateRequestFailureError    = 2;
     return [CPSet setWithObjects:"state"];
 }
 
-- (void)init
+- (id)init
 {
     if (self = [super init])
     {


### PR DESCRIPTION
The Objective-J compiler was warning about a conflicting return type in the WLRemoteLink.j init method. The return type was "void", but the method was actually returning something.

This commit changes the return type to 'id'.
