### PR TITLE
Fixed: Typedefs for variables raised warnings

### DIFF
--- a/WLRemoteLink.j
+++ b/WLRemoteLink.j
@@ -33,6 +33,8 @@
 
 @import <Foundation/Foundation.j>
 
+@typedef WLRemoteActionType
+
 var SharedWLRemoteLink      = nil,
     DefaultBaseUrl          = '/api/',
     WLRemoteLinkRetryDelay  = 10; // in seconds

--- a/WLRemoteObject.j
+++ b/WLRemoteObject.j
@@ -936,7 +936,7 @@ function CamelCaseToHyphenated(camelCase)
     CPString            localName @accessors;
     CPString            remoteName @accessors;
     CPValueTransformer  valueTransformer @accessors;
-    boolean             loadOnly @accessors(getter=isLoadOnly);
+    BOOL                loadOnly @accessors(getter=isLoadOnly);
 }
 
 + (id)propertyWithName:(CPString)aName


### PR DESCRIPTION
The new @typedef functionality for Cappuccino raised a warning on several undefined types. This commit adds @typedefs or changes them to existing types.
